### PR TITLE
Use quadratic kappa

### DIFF
--- a/src/optimization/monitoring.py
+++ b/src/optimization/monitoring.py
@@ -37,7 +37,11 @@ class APTOSMonitor:
 
         self._summary_writer.add_scalar(
             tag="cohen_kappa_score",
-            scalar_value=cohen_kappa_score(targets, predictions),
+            scalar_value=cohen_kappa_score(
+                targets,
+                predictions,
+                weights='quadratic',
+            ),
             global_step=epoch
         )
 


### PR DESCRIPTION
When calculating the kappa score, the current code has no weighting between categories.  The competition is scored on quadratically weighted kappa.